### PR TITLE
Add ViT training and inference notebook

### DIFF
--- a/vit_classification.ipynb
+++ b/vit_classification.ipynb
@@ -1,0 +1,270 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Vision Transformer (ViT) Image Classification\n",
+        "\n",
+        "This notebook fine-tunes a pretrained Vision Transformer (ViT) model from [Hugging Face](https://huggingface.co/models?search=vit) on the local image dataset contained in the repository. It also demonstrates how to run inference with the fine-tuned model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install -q transformers datasets evaluate accelerate torchvision pillow"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import numpy as np\n",
+        "from datasets import load_dataset\n",
+        "import evaluate\n",
+        "from PIL import Image\n",
+        "\n",
+        "import torch\n",
+        "from torchvision import transforms\n",
+        "from transformers import (\n",
+        "    AutoImageProcessor,\n",
+        "    ViTForImageClassification,\n",
+        "    TrainingArguments,\n",
+        "    Trainer,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Paths to the training and validation folders\n",
+        "project_dir = Path.cwd()\n",
+        "train_dir = project_dir / 'train'\n",
+        "valid_dir = project_dir / 'valid'\n",
+        "\n",
+        "assert train_dir.exists(), f'Training directory not found: {train_dir}'\n",
+        "assert valid_dir.exists(), f'Validation directory not found: {valid_dir}'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Load datasets from the image folders\n",
+        "dataset = load_dataset(\n",
+        "    'imagefolder',\n",
+        "    data_dir={'train': str(train_dir), 'validation': str(valid_dir)},\n",
+        ")\n",
+        "\n",
+        "label_names = dataset['train'].features['label'].names\n",
+        "num_labels = len(label_names)\n",
+        "label2id = {label: idx for idx, label in enumerate(label_names)}\n",
+        "id2label = {idx: label for label, idx in label2id.items()}\n",
+        "\n",
+        "print('Labels:', label_names)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Load pretrained image processor and define transforms\n",
+        "checkpoint = 'google/vit-base-patch16-224-in21k'\n",
+        "image_processor = AutoImageProcessor.from_pretrained(checkpoint)\n",
+        "\n",
+        "size = image_processor.size['height']\n",
+        "normalize = transforms.Normalize(mean=image_processor.image_mean, std=image_processor.image_std)\n",
+        "\n",
+        "train_transforms = transforms.Compose([\n",
+        "    transforms.Resize((size, size)),\n",
+        "    transforms.RandomHorizontalFlip(),\n",
+        "    transforms.ToTensor(),\n",
+        "    normalize,\n",
+        "])\n",
+        "\n",
+        "valid_transforms = transforms.Compose([\n",
+        "    transforms.Resize((size, size)),\n",
+        "    transforms.ToTensor(),\n",
+        "    normalize,\n",
+        "])\n",
+        "\n",
+        "def preprocess_train(examples):\n",
+        "    examples['pixel_values'] = [train_transforms(image.convert('RGB')) for image in examples['image']]\n",
+        "    return examples\n",
+        "\n",
+        "def preprocess_eval(examples):\n",
+        "    examples['pixel_values'] = [valid_transforms(image.convert('RGB')) for image in examples['image']]\n",
+        "    return examples\n",
+        "\n",
+        "train_dataset = dataset['train'].map(\n",
+        "    preprocess_train,\n",
+        "    batched=True,\n",
+        "    remove_columns=['image'],\n",
+        "    desc='Applying train transforms',\n",
+        "    load_from_cache_file=False,\n",
+        ")\n",
+        "eval_dataset = dataset['validation'].map(\n",
+        "    preprocess_eval,\n",
+        "    batched=True,\n",
+        "    remove_columns=['image'],\n",
+        "    desc='Applying validation transforms',\n",
+        "    load_from_cache_file=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "metric = evaluate.load('accuracy')\n",
+        "\n",
+        "def compute_metrics(eval_pred):\n",
+        "    logits, labels = eval_pred\n",
+        "    predictions = np.argmax(logits, axis=-1)\n",
+        "    return metric.compute(predictions=predictions, references=labels)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = ViTForImageClassification.from_pretrained(\n",
+        "    checkpoint,\n",
+        "    num_labels=num_labels,\n",
+        "    label2id=label2id,\n",
+        "    id2label=id2label,\n",
+        "    ignore_mismatched_sizes=True,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "training_args = TrainingArguments(\n",
+        "    output_dir='vit-output',\n",
+        "    per_device_train_batch_size=8,\n",
+        "    per_device_eval_batch_size=8,\n",
+        "    num_train_epochs=5,\n",
+        "    learning_rate=5e-5,\n",
+        "    weight_decay=0.01,\n",
+        "    evaluation_strategy='epoch',\n",
+        "    save_strategy='epoch',\n",
+        "    load_best_model_at_end=True,\n",
+        "    metric_for_best_model='accuracy',\n",
+        "    logging_steps=10,\n",
+        "    remove_unused_columns=False,\n",
+        "    push_to_hub=False,\n",
+        "    fp16=torch.cuda.is_available(),\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def collate_fn(batch):\n",
+        "    pixel_values = torch.stack([example['pixel_values'] for example in batch])\n",
+        "    labels = torch.tensor([example['label'] for example in batch])\n",
+        "    return {'pixel_values': pixel_values, 'labels': labels}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "trainer = Trainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=train_dataset,\n",
+        "    eval_dataset=eval_dataset,\n",
+        "    tokenizer=image_processor,\n",
+        "    compute_metrics=compute_metrics,\n",
+        "    data_collator=collate_fn,\n",
+        ")\n",
+        "\n",
+        "train_result = trainer.train()\n",
+        "trainer.save_model()\n",
+        "trainer.log_metrics('train', train_result.metrics)\n",
+        "trainer.save_metrics('train', train_result.metrics)\n",
+        "trainer.save_state()\n",
+        "\n",
+        "metrics = trainer.evaluate()\n",
+        "trainer.log_metrics('eval', metrics)\n",
+        "trainer.save_metrics('eval', metrics)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Inference on a single image\n",
+        "image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.gif'}\n",
+        "image_path = next(\n",
+        "    path for path in train_dir.rglob('*')\n",
+        "    if path.is_file() and path.suffix.lower() in image_extensions\n",
+        ")\n",
+        "image = Image.open(image_path).convert('RGB')\n",
+        "inputs = image_processor(images=image, return_tensors='pt')\n",
+        "model = trainer.model\n",
+        "model.eval()\n",
+        "with torch.no_grad():\n",
+        "    outputs = model(**inputs)\n",
+        "    probs = outputs.logits.softmax(dim=-1).squeeze()\n",
+        "\n",
+        "predicted_idx = int(probs.argmax())\n",
+        "predicted_label = id2label[predicted_idx]\n",
+        "confidence = float(probs[predicted_idx])\n",
+        "\n",
+        "print(f'Image: {image_path.name}')\n",
+        "print(f'Predicted label: {predicted_label} (confidence {confidence:.2%})')\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> **Tip:** Training a ViT model can be computationally expensive. If you are running on limited hardware, consider reducing the number of epochs or using a smaller checkpoint such as `google/vit-base-patch16-224`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new Jupyter notebook that fine-tunes a Hugging Face ViT model on the local image classification dataset
- include preprocessing, training, evaluation, and single-image inference steps for the ViT workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df84e08c008321b8aaf68ca4be3e50