### PR TITLE
Fix Vision Transformer training configuration and data collator

### DIFF
--- a/vit_classification.ipynb
+++ b/vit_classification.ipynb
@@ -257,6 +257,7 @@
         "    remove_unused_columns=False,\n",
         "    push_to_hub=False,\n",
         "    fp16=torch.cuda.is_available(),\n",
+        "    report_to='none',\n",
         ")"
       ]
     },
@@ -267,8 +268,12 @@
       "outputs": [],
       "source": [
         "def collate_fn(batch):\n",
-        "    pixel_values = torch.stack([example['pixel_values'] for example in batch])\n",
-        "    labels = torch.tensor([example['label'] for example in batch])\n",
+        "    pixel_values = torch.stack([\n",
+        "        example['pixel_values'] if isinstance(example['pixel_values'], torch.Tensor)\n",
+        "        else torch.tensor(example['pixel_values'])\n",
+        "        for example in batch\n",
+        "    ])\n",
+        "    labels = torch.tensor([example['label'] for example in batch], dtype=torch.long)\n",
         "    return {'pixel_values': pixel_values, 'labels': labels}"
       ]
     },


### PR DESCRIPTION
## Summary
- add `report_to="none"` to the ViT `TrainingArguments` configuration
- convert list-based image batches to tensors inside the custom `collate_fn` and set label dtype

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df983675dc832187bc1acd81d44619